### PR TITLE
PHP 7.4+ Fix

### DIFF
--- a/TokenAuthGenerator.php
+++ b/TokenAuthGenerator.php
@@ -86,7 +86,7 @@ class TokenAuthGenerator {
 
     private function pkcs5Unpad($text) 
     {
-        $pad = ord($text{strlen($text) - 1});
+        $pad = ord($text[strlen($text) - 1]);
         if($pad > strlen($text))
         {
             return false;


### PR DESCRIPTION
Resolves: Array and string offset access syntax with curly braces is deprecated